### PR TITLE
Add runtime dependencies for tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,14 +4,19 @@
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
-		"": {
-			"name": "@sudowealth/schwab-api",
-			"version": "0.0.0-semantically-released",
-			"license": "MIT",
-			"devDependencies": {
-				"@epic-web/config": "^1.20.1",
-				"@types/node": "^20.10.4",
-				"@vitest/coverage-v8": "^3.1.3",
+                "": {
+                        "name": "@sudowealth/schwab-api",
+                        "version": "0.0.0-semantically-released",
+                        "license": "MIT",
+                        "dependencies": {
+                                "@epic-web/config": "^1.20.1",
+                                "tsx": "^4.6.2",
+                                "zod": "^3.0.0"
+                        },
+                        "devDependencies": {
+                                "@epic-web/config": "^1.20.1",
+                                "@types/node": "^20.10.4",
+                                "@vitest/coverage-v8": "^3.1.3",
 				"eslint": "^9.26.0",
 				"npm-run-all": "^4.1.5",
 				"prettier": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
     "trader",
     "market-data"
   ],
+  "dependencies": {
+    "@epic-web/config": "^1.20.1",
+    "tsx": "^4.6.2",
+    "zod": "^3.0.0"
+  },
   "devDependencies": {
     "@epic-web/config": "^1.20.1",
     "@types/node": "^20.10.4",

--- a/src/auth/token-handler.ts
+++ b/src/auth/token-handler.ts
@@ -89,13 +89,12 @@ export class BaseTokenHandler implements ITokenLifecycleManager {
 				this.fetchFn,
 			)
 
-			const response = await exchangeCodeForTokenWithContext(context, {
-				clientId: this.clientId,
-				clientSecret: this.clientSecret,
-				code,
-				redirectUri: this.redirectUri,
-				fetch: this.fetchFn,
-			})
+                       const response = await exchangeCodeForTokenWithContext(context, {
+                                clientId: this.clientId,
+                                clientSecret: this.clientSecret,
+                                code,
+                                redirectUri: this.redirectUri,
+                        })
 
 			const tokenSet = mapTokenResponse(response)
 
@@ -200,12 +199,11 @@ export class BaseTokenHandler implements ITokenLifecycleManager {
 				this.fetchFn,
 			)
 
-			const response = await refreshTokenWithContext(context, {
-				clientId: this.clientId,
-				clientSecret: this.clientSecret,
-				refreshToken: refreshTokenToUse,
-				fetch: this.fetchFn,
-			})
+                        const response = await refreshTokenWithContext(context, {
+                                clientId: this.clientId,
+                                clientSecret: this.clientSecret,
+                                refreshToken: refreshTokenToUse,
+                        })
 
 			// Use the new refresh token if provided, otherwise keep the old one
 			const refreshTokenToSave = response.refresh_token || refreshTokenToUse

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -5,20 +5,18 @@ import { type SchwabTokenResponse } from './types'
 import { getTokenUrlWithContext } from './urls'
 
 export interface ExchangeCodeForTokenOptions {
-	clientId: string
-	clientSecret: string
-	code: string
-	redirectUri: string
-	tokenUrl?: string // default from getTokenUrlWithContext()
-	fetch?: typeof fetch // Optional fetch override
+        clientId: string
+        clientSecret: string
+        code: string
+        redirectUri: string
+        tokenUrl?: string // default from getTokenUrlWithContext()
 }
 
 export interface RefreshTokenOptions {
-	clientId: string
-	clientSecret: string
-	refreshToken: string
-	tokenUrl?: string // default from getTokenUrlWithContext()
-	fetch?: typeof fetch // Optional fetch override
+        clientId: string
+        clientSecret: string
+        refreshToken: string
+        tokenUrl?: string // default from getTokenUrlWithContext()
 }
 
 /**
@@ -52,7 +50,7 @@ export async function exchangeCodeForTokenWithContext(
 	opts: ExchangeCodeForTokenOptions,
 ): Promise<SchwabTokenResponse> {
 	const { config } = context
-	const fetchFn = opts.fetch || context.fetchFn
+        const fetchFn = context.fetchFn
 	const tokenEndpoint = opts.tokenUrl || getTokenUrlWithContext(context)
 
 	const body = new URLSearchParams()
@@ -122,7 +120,7 @@ export async function refreshTokenWithContext(
 	opts: RefreshTokenOptions,
 ): Promise<SchwabTokenResponse> {
 	const { config } = context
-	const fetchFn = opts.fetch || context.fetchFn
+        const fetchFn = context.fetchFn
 	const tokenEndpoint = opts.tokenUrl || getTokenUrlWithContext(context)
 
 	const body = new URLSearchParams()


### PR DESCRIPTION
## Summary
- declare `@epic-web/config`, `tsx` and `zod` as runtime deps
- update package lock
- keep token option interfaces without a `fetch` override

## Testing
- `npm run lint` *(fails: cannot find module `@epic-web/config`)*
- `npm test` *(fails: `tsx` not found)*
- `npm run typecheck` *(fails: missing `@types/node`)*