### PR TITLE
Integrate openid-client based auth

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,11 +1,10 @@
-import { BaseTokenHandler } from './token-handler'
+import { OpenIdTokenManager } from './openid-manager'
 import {
 	type ITokenLifecycleManager,
 	buildTokenManager,
 } from './token-lifecycle-manager'
 import {
 	type AuthClientOptions,
-	type TokenSet,
 	type TokenData,
 	type RefreshOptions,
 	type FullAuthClient,
@@ -66,61 +65,6 @@ export interface AuthFactoryConfig {
 export type { FullAuthClient }
 
 /**
- * Token manager for OAuth flow that leverages BaseTokenHandler's implementation.
- * This class extends BaseTokenHandler to provide a simplified interface
- * for token management in the OAuth flow.
- */
-class OAuthTokenManager extends BaseTokenHandler {
-	constructor(options: AuthClientOptions) {
-		super(options)
-	}
-
-	/**
-	 * Exchange an authorization code for tokens
-	 * Uses BaseTokenHandler's implementation
-	 */
-	async exchangeCode(code: string): Promise<TokenSet> {
-		this.tokenSet = await super.exchangeCode(code)
-		// Update refresh token created timestamp
-		this.refreshTokenCreatedAt = Date.now()
-		return this.tokenSet
-	}
-
-	/**
-	 * Register a callback for token refresh events
-	 * Uses BaseTokenHandler's onRefresh implementation
-	 */
-	onRefresh(callback: (tokenSet: TokenSet) => void): void {
-		super.onRefresh(callback)
-	}
-
-	/**
-	 * Refreshes tokens if needed
-	 * Provides a simplified interface using BaseTokenHandler's implementation
-	 */
-	async refreshIfNeeded(options?: RefreshOptions): Promise<TokenData> {
-		// Get current tokens
-		const currentTokens = await this.getTokenData()
-
-		if (!currentTokens || !currentTokens.refreshToken) {
-			throw new Error('No refresh token available')
-		}
-
-		// Refresh the tokens through the base handler
-		this.tokenSet = await super.refreshTokens({
-			refreshToken: currentTokens.refreshToken,
-			force: options?.force,
-		})
-
-		return {
-			accessToken: this.tokenSet.accessToken,
-			refreshToken: this.tokenSet.refreshToken,
-			expiresAt: this.tokenSet.expiresAt,
-		}
-	}
-}
-
-/**
  * Creates a unified authentication client that handles various authentication strategies
  *
  * This function simplifies authentication by providing a consistent interface
@@ -176,7 +120,7 @@ export function createSchwabAuth(
 				throw new Error('oauthConfig is required for CODE_FLOW strategy')
 			}
 
-			const oauthManager = new OAuthTokenManager(config.oauthConfig)
+			const oauthManager = new OpenIdTokenManager(config.oauthConfig)
 			return buildTokenManager(oauthManager) as ITokenLifecycleManager
 
 		case AuthStrategy.STATIC.toLowerCase():

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -15,6 +15,7 @@ export * from './token-utils'
 
 // Core token handling components
 export { BaseTokenHandler, mapTokenResponse } from './token-handler'
+export { OpenIdTokenManager } from './openid-manager'
 
 // Token management architecture components
 export * from './token-lifecycle-manager'

--- a/src/auth/openid-manager.ts
+++ b/src/auth/openid-manager.ts
@@ -1,0 +1,135 @@
+import * as oidc from 'openid-client'
+import {
+	type AuthClientOptions,
+	type ITokenLifecycleManager,
+	type TokenData,
+	type TokenSet,
+	type RefreshOptions,
+} from './types'
+import { API_URLS, API_VERSIONS } from '../constants'
+
+export interface OpenIdManagerOptions extends AuthClientOptions {
+	issuerBaseUrl?: string
+}
+
+export class OpenIdTokenManager implements ITokenLifecycleManager {
+	private config: oidc.Configuration
+	private tokenSet?: oidc.TokenEndpointResponse &
+		oidc.TokenEndpointResponseHelpers
+	private defaultScope: string[]
+	private loadFn?: () => Promise<TokenSet | null>
+	private saveFn?: (t: TokenSet) => Promise<void>
+	private refreshCallbacks: Array<(t: TokenSet) => void> = []
+
+	constructor(options: OpenIdManagerOptions) {
+		const base =
+			options.issuerBaseUrl ?? `${API_URLS.PRODUCTION}/${API_VERSIONS.v1}`
+		const server = {
+			issuer: base,
+			authorization_endpoint: `${base}/oauth/authorize`,
+			token_endpoint: `${base}/oauth/token`,
+		} as oidc.ServerMetadata
+
+		this.config = new oidc.Configuration(server, options.clientId, {
+			client_secret: options.clientSecret,
+			redirect_uris: [options.redirectUri],
+		})
+		this.defaultScope = options.scope ?? ['api', 'offline_access']
+		this.loadFn = options.load
+		this.saveFn = options.save
+	}
+
+	getAuthorizationUrl(opts?: { scope?: string[]; state?: string }): {
+		authUrl: string
+	} {
+		const redirectUris = this.config.clientMetadata().redirect_uris as
+			| string[]
+			| undefined
+		const redirectUri = (redirectUris ? redirectUris[0] : '') as string
+		const parameters: Record<string, string> = {
+			redirect_uri: redirectUri,
+			scope: (opts?.scope ?? this.defaultScope).join(' '),
+		}
+		if (opts?.state) parameters.state = opts.state
+		const url = oidc.buildAuthorizationUrl(this.config, parameters)
+		return { authUrl: url.toString() }
+	}
+
+	async exchangeCode(code: string): Promise<TokenSet> {
+		const redirectUris = this.config.clientMetadata().redirect_uris as
+			| string[]
+			| undefined
+		const redirectUri = (redirectUris ? redirectUris[0] : '') as string
+		const url = new URL(redirectUri)
+		url.searchParams.set('code', code)
+		this.tokenSet = await oidc.authorizationCodeGrant(this.config, url)
+		const data = this.mapTokenSet(this.tokenSet)
+		await this.saveFn?.(data)
+		return data
+	}
+
+	private mapTokenSet(ts: oidc.TokenEndpointResponse): TokenSet {
+		return {
+			accessToken: ts.access_token!,
+			refreshToken: ts.refresh_token ?? '',
+			expiresAt: ts.expires_in ? Date.now() + ts.expires_in * 1000 : Date.now(),
+		}
+	}
+
+	private async ensureTokenSet(): Promise<
+		oidc.TokenEndpointResponse | undefined
+	> {
+		if (!this.tokenSet && this.loadFn) {
+			const saved = await this.loadFn()
+			if (saved) {
+				const expiresIn = Math.max(
+					0,
+					Math.floor((saved.expiresAt - Date.now()) / 1000),
+				)
+				this.tokenSet = {
+					access_token: saved.accessToken,
+					refresh_token: saved.refreshToken,
+					expires_in: expiresIn,
+				} as any
+			}
+		}
+		return this.tokenSet
+	}
+
+	async getTokenData(): Promise<TokenData | null> {
+		const ts = await this.ensureTokenSet()
+		return ts ? this.mapTokenSet(ts) : null
+	}
+
+	async getAccessToken(): Promise<string | null> {
+		const data = await this.getTokenData()
+		return data?.accessToken ?? null
+	}
+
+	supportsRefresh(): boolean {
+		return true
+	}
+
+	onRefresh(cb: (t: TokenSet) => void): void {
+		this.refreshCallbacks.push(cb)
+	}
+
+	async refreshIfNeeded(options?: RefreshOptions): Promise<TokenData> {
+		const ts = await this.ensureTokenSet()
+		if (!ts?.refresh_token) {
+			throw new Error('No refresh token available')
+		}
+		const expiresIn = ts.expires_in
+		if (options?.force || expiresIn === undefined || expiresIn <= 60) {
+			this.tokenSet = await oidc.refreshTokenGrant(
+				this.config,
+				ts.refresh_token,
+			)
+			const data = this.mapTokenSet(this.tokenSet)
+			await this.saveFn?.(data)
+			this.refreshCallbacks.forEach((cb) => cb(data))
+			return data
+		}
+		return this.mapTokenSet(ts)
+	}
+}


### PR DESCRIPTION
## Summary
- replace custom OAuth manager with OpenIdTokenManager built on openid-client
- expose `OpenIdTokenManager` via auth index

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npm test`
