### PR TITLE
Update endpoint auth flow

### DIFF
--- a/src/core/endpoint-types.ts
+++ b/src/core/endpoint-types.ts
@@ -38,22 +38,13 @@ export type EndpointFunction<T extends EndpointMetadata> = (
  * Determines the arguments for an endpoint function based on the metadata
  */
 type EndpointFunctionArgs<T extends EndpointMetadata> =
-	HasRequiredParams<T> extends true
-		? [
-				// Access token is always required
-				accessToken: string,
-				options: BuildEndpointOptions<T>,
-			]
-		: HasOptionalParams<T> extends true
-			? [
-					// Access token is always required, options are optional
-					accessToken: string,
-					options?: BuildEndpointOptions<T>,
-				]
-			: [
-					// Just the access token if no other parameters are needed
-					accessToken: string,
-				]
+        HasRequiredParams<T> extends true
+                ? [
+                                options: BuildEndpointOptions<T>,
+                        ]
+                : HasOptionalParams<T> extends true
+                        ? [options?: BuildEndpointOptions<T>]
+                        : []
 
 /**
  * Builds the options parameter type based on what's available in the metadata

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -106,29 +106,20 @@ function log(
  * All API requests should use this function
  */
 async function schwabFetchWithContext<
-	P,
-	Q,
-	B,
-	R,
-	M extends HttpMethod,
-	E = unknown,
+        P,
+        Q,
+        B,
+        R,
+        M extends HttpMethod,
+        E = unknown,
 >(
-	context: RequestContext,
-	accessToken: string | null, // Authentication token required for all endpoints
-	endpoint: EndpointMetadata<P, Q, B, R, M, E>,
-	options?: SchwabFetchRequestOptions<P, Q, B>,
+        context: RequestContext,
+        endpoint: EndpointMetadata<P, Q, B, R, M, E>,
+        options?: SchwabFetchRequestOptions<P, Q, B>,
 ): Promise<R> {
-	const { config, fetchFn } = context
-	log(context, 'info', `Requesting: ${endpoint.method} ${endpoint.path}`)
-	log(context, 'debug', 'Request details:', { endpoint, options })
-
-	if (!accessToken) {
-		throw createSchwabApiError(
-			401,
-			undefined,
-			`Access token is required for endpoint ${endpoint.method} ${endpoint.path}`,
-		)
-	}
+        const { config, fetchFn } = context
+        log(context, 'info', `Requesting: ${endpoint.method} ${endpoint.path}`)
+        log(context, 'debug', 'Request details:', { endpoint, options })
 
 	const { pathParams, queryParams, body, init = {} } = options ?? {}
 	const {
@@ -292,11 +283,10 @@ async function schwabFetchWithContext<
 		)
 	}
 
-	const headers: Record<string, string> = {
-		...(options?.headers ?? {}), // User-provided headers
-		Accept: 'application/json',
-		...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-	}
+        const headers: Record<string, string> = {
+                ...(options?.headers ?? {}), // User-provided headers
+                Accept: 'application/json',
+        }
 
 	const requestInit: RequestInit = {
 		...init,
@@ -461,27 +451,18 @@ async function schwabFetchWithContext<
  * This is the primary way to create API endpoint functions
  */
 export function createEndpoint<P, Q, B, R, M extends HttpMethod, E = unknown>(
-	context: RequestContext,
-	meta: EndpointMetadata<P, Q, B, R, M, E>,
+        context: RequestContext,
+        meta: EndpointMetadata<P, Q, B, R, M, E>,
 ) {
-	return (
-		accessToken: string,
-		options: SchwabFetchRequestOptions<P, Q, B> = {},
-	): Promise<R> => {
-		if (!accessToken) {
-			throw createSchwabApiError(
-				401,
-				undefined,
-				'Access token is required for this endpoint.',
-			)
-		}
-		return schwabFetchWithContext<P, Q, B, R, M, E>(
-			context,
-			accessToken,
-			meta,
-			options,
-		)
-	}
+        return (
+                options: SchwabFetchRequestOptions<P, Q, B> = {},
+        ): Promise<R> => {
+                return schwabFetchWithContext<P, Q, B, R, M, E>(
+                        context,
+                        meta,
+                        options,
+                )
+        }
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove access token argument from `createEndpoint`
- adjust `EndpointFunctionArgs` to only accept an options object
- rely on middleware to handle Authorization header

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
