### PR TITLE
Fix path parameter encoding

### DIFF
--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -490,19 +490,19 @@ function buildUrlWithContext(
 					/[.*+?^${}()|[\]\\]/g,
 					'\\$&',
 				)
-				finalEndpointPath = finalEndpointPath.replace(
-					new RegExp(escapedPlaceholder, 'g'),
-					String(value),
-				)
+                                finalEndpointPath = finalEndpointPath.replace(
+                                        new RegExp(escapedPlaceholder, 'g'),
+                                        encodeURIComponent(String(value)),
+                                )
 				replaced = true
 			}
 
 			// Check and replace colon-style placeholders separately
 			if (colonPlaceholderPattern.test(finalEndpointPath)) {
-				finalEndpointPath = finalEndpointPath.replace(
-					colonPlaceholderPattern,
-					String(value),
-				)
+                                finalEndpointPath = finalEndpointPath.replace(
+                                        colonPlaceholderPattern,
+                                        encodeURIComponent(String(value)),
+                                )
 				replaced = true
 			}
 


### PR DESCRIPTION
## Summary
- encode dynamic path parameters in URL builder to avoid traversal attacks

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
